### PR TITLE
Fix absence of center position in `SpiralIterator`

### DIFF
--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -46,7 +46,10 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 
 			@Override
 			public boolean hasNext() {
-				return x > lowerBound.getX() && x < upperBound.getX() && z > lowerBound.getZ() && z < upperBound.getZ();
+				if (j != 0) {
+					return true;
+				}
+				return x >= lowerBound.getX() && x <= upperBound.getX() && z >= lowerBound.getZ() && z <= upperBound.getZ();
 			}
 
 			@Override

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -46,7 +46,7 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 
 			@Override
 			public boolean hasNext() {
-				return x >= lowerBound.getX() && x <= upperBound.getX() && z >= lowerBound.getZ() && z <= upperBound.getZ();
+				return x > lowerBound.getX() && x < upperBound.getX() && z > lowerBound.getZ() && z < upperBound.getZ();
 			}
 
 			@Override

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -46,9 +46,6 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 
 			@Override
 			public boolean hasNext() {
-				if (j != 0) {
-					return true;
-				}
 				return x >= lowerBound.getX() && x <= upperBound.getX() && z >= lowerBound.getZ() && z <= upperBound.getZ();
 			}
 

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -39,10 +39,9 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 			private Integer x = null;
 			private Integer z = null;
 
-			float n = 1;
-			int floorN = 1;
-			int i = 0;
-			int j = 0;
+			private float n = 1;
+			private int i = 0;
+			private int j = 0;
 
 			@Override
 			public boolean hasNext() {
@@ -59,7 +58,7 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 					z = center.getZ();
 					return center;
 				}
-				floorN = (int) Math.floor(n);
+				int floorN = (int) Math.floor(n);
 				if (j < floorN) {
 					switch (i % 4) {
 						case 0: z += step; break;

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -16,20 +16,17 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 	private final int step;
 	private final Builder<T> builder;
 
-	public SpiralIterator(T center, T radius, int step, Builder<T> builder) {
-		this.center = center;
-		this.lowerBound = radius;
-		this.upperBound = radius;
-		this.step = step;
-		this.builder = builder;
-	}
-
 	public SpiralIterator(T center, T lowerBound, T upperBound, int step, Builder<T> builder) {
 		this.center = center;
 		this.lowerBound = lowerBound;
 		this.upperBound = upperBound;
 		this.step = step;
 		this.builder = builder;
+	}
+
+	public SpiralIterator(T center, T radius, int step, Builder<T> builder) {
+		this(center, builder.build(center.getX() - radius.getX(), 0, center.getZ() - radius.getZ()),
+			builder.build(center.getX() + radius.getX(), 0, center.getZ() + radius.getZ()), step, builder);
 	}
 
 	public SpiralIterator(T center, T radius, Builder<T> builder) {

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -36,8 +36,8 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 	@Override
 	public @NotNull Iterator<T> iterator() {
 		return new Iterator<T>() {
-			int x = center.getX();
-			int z = center.getZ();
+			private Integer x = null;
+			private Integer z = null;
 
 			float n = 1;
 			int floorN = 1;
@@ -46,11 +46,19 @@ public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
 
 			@Override
 			public boolean hasNext() {
+				if (x == null || z == null) {
+					return true;
+				}
 				return x >= lowerBound.getX() && x <= upperBound.getX() && z >= lowerBound.getZ() && z <= upperBound.getZ();
 			}
 
 			@Override
 			public T next() {
+				if (x == null || z == null) {
+					x = center.getX();
+					z = center.getZ();
+					return center;
+				}
 				floorN = (int) Math.floor(n);
 				if (j < floorN) {
 					switch (i % 4) {

--- a/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
+++ b/src/main/java/kaptainwutax/mcutils/util/data/SpiralIterator.java
@@ -1,0 +1,85 @@
+package kaptainwutax.mcutils.util.data;
+
+import kaptainwutax.mcutils.util.math.Vec3i;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+@SuppressWarnings("unused")
+public class SpiralIterator<T extends Vec3i> implements Iterable<T> {
+
+	private final T center;
+	private final T lowerBound;
+	private final T upperBound;
+	private final int step;
+	private final Builder<T> builder;
+
+	public SpiralIterator(T center, T radius, int step, Builder<T> builder) {
+		this.center = center;
+		this.lowerBound = radius;
+		this.upperBound = radius;
+		this.step = step;
+		this.builder = builder;
+	}
+
+	public SpiralIterator(T center, T lowerBound, T upperBound, int step, Builder<T> builder) {
+		this.center = center;
+		this.lowerBound = lowerBound;
+		this.upperBound = upperBound;
+		this.step = step;
+		this.builder = builder;
+	}
+
+	public SpiralIterator(T center, T radius, Builder<T> builder) {
+		this(center, radius, 1, builder);
+	}
+
+	@Override
+	public @NotNull Iterator<T> iterator() {
+		return new Iterator<T>() {
+			int x = center.getX();
+			int z = center.getZ();
+
+			float n = 1;
+			int floorN = 1;
+			int i = 0;
+			int j = 0;
+
+			@Override
+			public boolean hasNext() {
+				return x >= lowerBound.getX() && x <= upperBound.getX() && z >= lowerBound.getZ() && z <= upperBound.getZ();
+			}
+
+			@Override
+			public T next() {
+				floorN = (int) Math.floor(n);
+				if (j < floorN) {
+					switch (i % 4) {
+						case 0: z += step; break;
+						case 1: x += step; break;
+						case 2: z -= step; break;
+						case 3: x -= step; break;
+					}
+					j++;
+					return builder.build(x, 0, z);
+				}
+				j = 0;
+				n += 0.5;
+				i++;
+				return next();
+			}
+		};
+	}
+
+	@Override
+	public Spliterator<T> spliterator() {
+		return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.ORDERED);
+	}
+
+	@FunctionalInterface
+	public interface Builder<T extends Vec3i> {
+		T build(int x, int y, int z);
+	}
+}


### PR DESCRIPTION
A few things:
- I'm aware I could have used a `boolean` to check for the first call of `next`, there are a few reasons I did not do that and did do this.
  - Firstly, a new `boolean` would have to be created.
  - Anaylsis at runtime can determine a field cannot be `null`, e.g. because of an explicit check for null or because it was used more than once in code. This means the `null` check is easily optimized by the JVM.
  - Using `Integer` isn't slower than using the primitive type, as the JVM erases away small object creations.
- In both cases (a `null` check and a `boolean` check) the JVM performs branch prediction; a branch which is almost never taken can be skipped and effectively checked in parallel.